### PR TITLE
Batch limitation

### DIFF
--- a/mangascandl/extractor/Mangadex.py
+++ b/mangascandl/extractor/Mangadex.py
@@ -84,9 +84,10 @@ class Mangadex(MangaSiteExtractor):
         all_chapter_list = manga_info['chapter']
         ordered_chapter = {}
         for chapter_code, chapter_info in all_chapter_list.items():
-            chapter_index = float(chapter_info['chapter'])
-            if float(start) <= chapter_index <= float(end) and chapter_info['lang_code'] == 'gb':
-                ordered_chapter[chapter_index] = 'http://mangadex.org/chapter/' + chapter_code
+            if chapter_info['chapter'] != '':
+                chapter_index = float(chapter_info['chapter'])
+                if float(start) <= chapter_index <= float(end) and chapter_info['lang_code'] == 'gb':
+                     ordered_chapter[chapter_index] = 'http://mangadex.org/chapter/' + chapter_code
 
         ordered_chapter = OrderedDict(sorted(ordered_chapter.items()))
         return list(ordered_chapter.values())

--- a/mangascandl/extractor/common.py
+++ b/mangascandl/extractor/common.py
@@ -60,7 +60,7 @@ class BulkImageDownloader(threading.Thread):
             self.queue.task_done()
 
     def download_img(self, url, page_number):
-        filename = str(page_number) + ".jpg"
+        filename = str(page_number).zfill(3) + ".jpg"
         r = requests.get(url, stream=True)
         if r.status_code == 200:
             with open(self.destfolder + '/' + filename, 'wb') as f:


### PR DESCRIPTION
## When the value of the chapter is empty this error appear.
```
{'volume': '0', 'chapter': '', 'title': 'Oneshot - Прототип (SPOILERS!)', 'lang_name': 'Russian', 'lang_code': 'ru', 'group_id': 657, 'group_name': 'no group', 'group_id_2': 0, 'group_name_2': None, 'group_id_3': 0, 'group_name_3': None, 'timestamp': 1551788278, 'comments': None}
```

## Example

`$ mangascandl batch https://mangadex.org/title/286/ 1 4 'Fullmetal Alchemist Vol.01'`

```
Traceback (most recent call last):
  File "/home/alann/.local/bin/mangascandl", line 10, in <module>
    sys.exit(main())
  File "/home/alann/.local/lib/python3.7/site-packages/mangascandl/mangascandl.py", line 46, in main
    extractor.download_batch(opts.url,opts.starting_chapter,opts.end_chapter,opts.destination_folder)
  File "/home/alann/.local/lib/python3.7/site-packages/mangascandl/extractor/common.py", line 108, in download_batch
    chapter_url_list = self.get_chapter_url_to_download(title_url,start,end)
  File "/home/alann/.local/lib/python3.7/site-packages/mangascandl/extractor/Mangadex.py", line 85, in get_chapter_url_to_download
    chapter_index = float(chapter_info['chapter'])
ValueError: could not convert string to float:
```